### PR TITLE
Address snappy library encoding change

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -121,9 +121,6 @@ func (g *Gouchstore) writeChunk(buf []byte, header bool) (int64, int64, error) {
 }
 
 func (g *Gouchstore) writeCompressedChunk(buf []byte) (int64, int64, error) {
-	compressed, err := g.ops.SnappyEncode(nil, buf)
-	if err != nil {
-		return -1, -1, err
-	}
+	compressed := g.ops.SnappyEncode(nil, buf)
 	return g.writeChunk(compressed, false)
 }

--- a/gouch_ops.go
+++ b/gouch_ops.go
@@ -22,7 +22,7 @@ type GouchOps interface {
 	GotoEOF(f *os.File) (ret int64, err error)
 	Sync(f *os.File) error
 	CompactionTreeWriter(keyCompare btreeKeyComparator, reduce, rereduce reduceFunc, reduceContext interface{}) (TreeWriter, error)
-	SnappyEncode(dst, src []byte) ([]byte, error)
+	SnappyEncode(dst, src []byte) []byte
 	SnappyDecode(dst, src []byte) ([]byte, error)
 	Close(f *os.File) error
 }

--- a/gouch_ops_base.go
+++ b/gouch_ops_base.go
@@ -12,7 +12,7 @@ package gouchstore
 import (
 	"os"
 
-	"github.com/golang/snappy/snappy"
+	"github.com/golang/snappy"
 )
 
 type BaseGouchOps struct{}
@@ -45,7 +45,7 @@ func (g *BaseGouchOps) CompactionTreeWriter(keyCompare btreeKeyComparator, reduc
 	return NewOnDiskTreeWriter("", keyCompare, reduce, rereduce, reduceContext)
 }
 
-func (g *BaseGouchOps) SnappyEncode(dst, src []byte) ([]byte, error) {
+func (g *BaseGouchOps) SnappyEncode(dst, src []byte) []byte {
 	return snappy.Encode(dst, src)
 }
 


### PR DESCRIPTION
Snappy library has changed definition of Encode function and just returning encoded byte array - https://github.com/golang/snappy/blob/master/encode.go#L82
